### PR TITLE
Fix aircrack-ng fdsan error.

### DIFF
--- a/src/aircrack-ng/aircrack-ng.c
+++ b/src/aircrack-ng/aircrack-ng.c
@@ -63,6 +63,11 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#ifdef __ANDROID__
+#include <android/fdsan.h>
+#include <dlfcn.h>
+#endif
+
 #include "aircrack-ng/defs.h"
 #include "aircrack-ng/ce-wpa/crypto_engine.h"
 #include "aircrack-ng/aircrack-ng.h"
@@ -5945,6 +5950,20 @@ static void load_aircrack_crypto_dso(int simd_features)
 
 int main(int argc, char * argv[])
 {
+	
+	#ifdef __ANDROID__
+	    // For Android 11+.
+	    void *lib_handle = dlopen("libc.so", RTLD_LAZY);
+	    if (lib_handle) {
+	        void (*set_fdsan_error_level)(enum android_fdsan_error_level);
+	        set_fdsan_error_level = (void (*)(enum android_fdsan_error_level))dlsym(lib_handle, "android_fdsan_set_error_level");
+	        if (set_fdsan_error_level) {
+	            set_fdsan_error_level(ANDROID_FDSAN_ERROR_LEVEL_DISABLED);
+	        }
+	        dlclose(lib_handle);
+	    }
+	#endif
+
 	int i, n, ret, option, j, ret1, nbMergeBSSID;
 	int cpu_count, showhelp, z, zz, forceptw;
 	char *s, buf[128];


### PR DESCRIPTION
So... long story short:
https://github.com/pitube08642/aircrack-ng-for-termux/issues/13

Cracking .cap handshake handy with crunch or similar programm. So usually we do something like this:
$ crunch 8 8 0123 | aircrack-ng -b <MAC> dump-01.cap piping crunch output to the aircrack.
But in termux aircrack-ng v1.7 raises error:
fdsan: failed to exchange ownership of file descriptor: fd 0 is owned by FILE* 0x7625720028, was expected to be unowned

This fix is similar to termux cgdb (thanks Henrik) https://github.com/termux/termux-packages/commit/3abcd55aae5f9b180a3bff7e87671088bad59aa1

---------------------------------------------
Date:      Tue Feb 18 23:44:37 2025 +0300

On branch bugfix/termux_fdsan_error
Changes to be committed:
	modified:   src/aircrack-ng/aircrack-ng.c